### PR TITLE
When betta() is used with original data types and not the formula obj…

### DIFF
--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -40,6 +40,7 @@ Suggests: corncob,
     plyr,
     RCurl,
     rmarkdown,
-    tidyverse
+    tidyverse,
+    igraph
 VignetteBuilder: knitr
 URL: https://adw96.github.io/breakaway/

--- a/R/model_betta.R
+++ b/R/model_betta.R
@@ -139,7 +139,7 @@ betta <- function(chats = NULL, ses, X = NULL,
     }
   }
   if (!is.null(formula)) {
-    ses <- data[,deparse(substitute(ses))]
+    ses <- data[,deparse(substitute(ses))] + 1
     X <- stats::model.matrix(formula, data)
     chats <- stats::model.response(stats::model.frame(formula = formula, data = data))
   }

--- a/R/model_betta_random.R
+++ b/R/model_betta_random.R
@@ -75,7 +75,7 @@ betta_random <- function(chats = NULL, ses, X = NULL, groups = NULL, formula = N
     }
   }
   if (!is.null(formula)) {
-    ses <- data[,deparse(substitute(ses))]
+    ses <- data[,deparse(substitute(ses))] + 1
     group_var <- lme4:::barnames(lme4::findbars(lme4:::RHSForm(formula)))
     groups <- data[,group_var]
     full_form <- lme4::subbars(formula)


### PR DESCRIPTION
…ect, add 1 to each element in ses. This should break a test in testthat for betta(), because now betta() will give a different response when used with the original data types versus the formula configuration, and the outputs will no longer be equal. This is to test whether github actions flags this failed test.